### PR TITLE
chore(automation): add claude-codex loop state machine and guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,17 +2,21 @@
 name: Implementation Task
 about: AI-consumable task with full context and acceptance criteria
 title: ''
-labels: ''
+labels: 'task,backlog'
 assignees: ''
 ---
 
-## Context
+## Problem
 
-<!-- Why this change is needed -->
+<!-- What is broken or missing? -->
 
 ## Spec
 
 <!-- Exact interface, behavior, function signatures -->
+
+## Out of Scope
+
+<!-- Explicitly list what this issue must NOT change -->
 
 ## Files to Modify
 
@@ -24,9 +28,17 @@ assignees: ''
 
 ## Acceptance Criteria
 
-- [ ] All existing tests pass
+- [ ] Behavior matches Spec exactly
+- [ ] Existing tests pass
 - [ ] New tests cover the change
-- [ ] Code follows project conventions (see AGENTS.md)
+- [ ] No regression in related CLI features
+
+## Automation Policy
+
+<!-- Guardrails for PM/Dev automation loop -->
+- Max automated attempts: 3
+- If same failure repeats 2+ times, add `needs-human` and stop auto-retry
+- Do not auto-merge without Claude approval + CI green
 
 ## References
 

--- a/.github/automation/OPERATING_MODEL.md
+++ b/.github/automation/OPERATING_MODEL.md
@@ -1,0 +1,30 @@
+# PM/Dev Automation Operating Model
+
+## Roles
+- Claude PM: issue definition, review decision, prioritization.
+- Codex Dev: implementation, tests, PR delivery.
+
+## State Machine
+- `backlog` -> `ready-codex` -> `in-progress` -> `needs-claude-review` -> `approved` -> `done`
+- Exception states: `blocked`, `needs-human`
+
+## Automation Jobs
+- `automation-label-bootstrap.yml`: ensures required labels exist.
+- `automation-state-machine.yml`:
+  - issue enters execution when labeled `ready-codex`
+  - PRs are labeled `needs-claude-review`
+  - merged PRs are labeled `done`
+  - optional follow-up issue generation when PR has `auto-loop`
+- `claude-review-scheduler.yml`:
+  - reminds pending Claude review every 6h (max 3 reminders)
+  - escalates to `needs-human` + `blocked` after max reminders
+
+## Loop Prevention Rules
+- Max automated issue attempts: 3
+- Max review reminders: 3
+- Escalate to `needs-human` when thresholds are exceeded
+- Follow-up issue creation is opt-in via `auto-loop` label only
+
+## Merge Gate
+- Required: CI green + Claude approval
+- Do not auto-merge when PR is `blocked` or `needs-human`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What changed and why -->
+
+## Linked Issues
+
+<!-- Use closing keywords: Closes #123 -->
+
+## Verification
+
+<!-- Exact commands and key outputs -->
+- [ ] Tests passed locally
+- [ ] CI passed
+- [ ] No unrelated files changed
+
+## Risks
+
+<!-- Behavior/regression risks and mitigations -->
+
+## Handoff To Claude PM
+
+<!-- Keep this concise and actionable -->
+- Review focus:
+- Open questions:
+- Suggested next issue:

--- a/.github/workflows/automation-label-bootstrap.yml
+++ b/.github/workflows/automation-label-bootstrap.yml
@@ -1,0 +1,63 @@
+name: Automation Label Bootstrap
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  bootstrap-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure automation labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'task', color: '0E8A16', description: 'Tracked implementation task' },
+              { name: 'backlog', color: 'BFD4F2', description: 'Queued but not ready for execution' },
+              { name: 'ready-codex', color: '1D76DB', description: 'Ready for Codex execution' },
+              { name: 'in-progress', color: 'FBCA04', description: 'Actively being implemented' },
+              { name: 'needs-claude-review', color: '5319E7', description: 'Awaiting Claude PM review' },
+              { name: 'approved', color: '0E8A16', description: 'Approved for merge' },
+              { name: 'blocked', color: 'D93F0B', description: 'Blocked by dependency or risk' },
+              { name: 'needs-human', color: 'B60205', description: 'Automation halted, human decision required' },
+              { name: 'done', color: 'C2E0C6', description: 'Completed and verified' },
+              { name: 'auto-loop', color: '0052CC', description: 'Opt-in: create follow-up PM issue after merge' },
+              { name: 'ready-claude', color: '5319E7', description: 'Ready for Claude PM planning/review' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                });
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+                core.info(`Updated label: ${label.name}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                  core.info(`Created label: ${label.name}`);
+                } else {
+                  throw error;
+                }
+              }
+            }

--- a/.github/workflows/automation-state-machine.yml
+++ b/.github/workflows/automation-state-machine.yml
@@ -1,0 +1,227 @@
+name: Automation State Machine
+
+on:
+  issues:
+    types: [labeled, reopened]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  issue-ready-codex:
+    if: |
+      github.event_name == 'issues' &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'ready-codex') ||
+        github.event.action == 'reopened'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Transition issue into execution state
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const issueNumber = issue.number;
+            const maxAttempts = 3;
+            const labels = issue.labels.map(l => l.name);
+
+            if (!labels.includes('ready-codex')) {
+              core.info('Issue is not ready-codex; skipping.');
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const attemptMarker = '<!-- codex-attempt -->';
+            const attempts = comments.filter(c => c.body && c.body.includes(attemptMarker)).length;
+
+            const labelSet = new Set(labels);
+            const applyLabels = async (nextSet) => {
+              await github.rest.issues.setLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [...nextSet],
+              });
+            };
+
+            if (attempts >= maxAttempts) {
+              labelSet.delete('ready-codex');
+              labelSet.delete('in-progress');
+              labelSet.add('blocked');
+              labelSet.add('needs-human');
+              await applyLabels(labelSet);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: [
+                  '<!-- codex-stop -->',
+                  'Automation halted: reached max automated attempts (3).',
+                  'Please perform human triage and then relabel with `ready-codex` if retry is still valid.',
+                ].join('\n'),
+              });
+              return;
+            }
+
+            labelSet.add('in-progress');
+            labelSet.delete('backlog');
+            labelSet.delete('blocked');
+            labelSet.delete('needs-human');
+            labelSet.delete('done');
+            await applyLabels(labelSet);
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                '<!-- codex-attempt -->',
+                `Codex execution started (attempt ${attempts + 1}/${maxAttempts}).`,
+                'Next transition expected: `PR_OPEN` -> `needs-claude-review`.',
+              ].join('\n'),
+            });
+
+  pr-review-request:
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(fromJSON('["opened","reopened","synchronize","ready_for_review"]'), github.event.action)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark PR as pending Claude review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+            const labels = new Set((pr.labels || []).map(l => l.name));
+            labels.add('needs-claude-review');
+            labels.delete('approved');
+            labels.delete('done');
+
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [...labels],
+            });
+
+            const sha = pr.head.sha;
+            const marker = `<!-- claude-review-request:${sha} -->`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const alreadyPosted = comments.some(c => c.body && c.body.includes(marker));
+            if (alreadyPosted) {
+              core.info('Review request already posted for this SHA.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                marker,
+                'Codex implementation update is ready for Claude PM review.',
+                'Review gate: spec match, risk checks, and merge/no-merge decision.',
+              ].join('\n'),
+            });
+
+  pr-merged-closeout:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close out merged PR and optionally create follow-up issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+            const labels = new Set((pr.labels || []).map(l => l.name));
+            const hasAutoLoop = labels.has('auto-loop');
+
+            labels.add('done');
+            labels.delete('needs-claude-review');
+            labels.delete('in-progress');
+            labels.delete('ready-codex');
+            labels.delete('blocked');
+
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [...labels],
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                '<!-- codex-complete -->',
+                `Completed and merged in ${pr.merge_commit_sha}.`,
+                'State transition: `MERGED -> DONE`.',
+              ].join('\n'),
+            });
+
+            const body = pr.body || '';
+            const refs = [...body.matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/ig)]
+              .map(m => Number(m[1]))
+              .filter(n => Number.isFinite(n));
+            const uniqueRefs = [...new Set(refs)];
+
+            for (const issueNumber of uniqueRefs) {
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `Implemented by PR #${prNumber} and merged in \`${pr.merge_commit_sha}\`.`,
+                });
+              } catch (error) {
+                core.warning(`Failed to comment on issue #${issueNumber}: ${error.message}`);
+              }
+            }
+
+            if (!hasAutoLoop) {
+              core.info('auto-loop label absent; skipping follow-up PM issue creation.');
+              return;
+            }
+
+            const followUpTitle = `pm: post-merge review for PR #${prNumber}`;
+            const followUpBody = [
+              `Source PR: #${prNumber}`,
+              '',
+              '## Claude PM Review',
+              '- Validate merged behavior against acceptance criteria',
+              '- Identify residual risks and missing tests',
+              '- Decide whether a new Codex issue is required',
+              '',
+              '## Next Action',
+              '- If more work is needed, create a new issue and label it `ready-codex`',
+              '- If no further action is needed, close this issue',
+              '',
+              '<!-- auto-loop-followup -->',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: followUpTitle,
+              body: followUpBody,
+              labels: ['task', 'ready-claude', 'backlog'],
+            });

--- a/.github/workflows/claude-review-scheduler.yml
+++ b/.github/workflows/claude-review-scheduler.yml
@@ -1,0 +1,97 @@
+name: Claude Review Scheduler
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */2 * * *"
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  remind-claude-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remind and escalate stale review requests
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const maxReminders = 3;
+            const minHoursBetweenReminders = 6;
+            const reminderMarker = '<!-- claude-review-reminder -->';
+            const escalationMarker = '<!-- claude-review-escalated -->';
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              if (pr.draft) {
+                continue;
+              }
+              const labels = new Set((pr.labels || []).map(l => l.name));
+              if (!labels.has('needs-claude-review')) {
+                continue;
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+
+              const reminderComments = comments.filter(c => c.body && c.body.includes(reminderMarker));
+              const remindersSent = reminderComments.length;
+
+              if (remindersSent >= maxReminders) {
+                labels.delete('needs-claude-review');
+                labels.add('needs-human');
+                labels.add('blocked');
+                await github.rest.issues.setLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [...labels],
+                });
+
+                const escalatedAlready = comments.some(c => c.body && c.body.includes(escalationMarker));
+                if (!escalatedAlready) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: [
+                      escalationMarker,
+                      'Claude review reminders reached max count (3).',
+                      'Escalated to `needs-human` + `blocked` to prevent unattended looping.',
+                    ].join('\n'),
+                  });
+                }
+                continue;
+              }
+
+              if (reminderComments.length > 0) {
+                const lastReminder = new Date(reminderComments[reminderComments.length - 1].created_at);
+                const elapsedHours = (Date.now() - lastReminder.getTime()) / (1000 * 60 * 60);
+                if (elapsedHours < minHoursBetweenReminders) {
+                  continue;
+                }
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: [
+                  reminderMarker,
+                  `Review reminder ${remindersSent + 1}/${maxReminders}: Claude PM review is pending.`,
+                  '@baekho-lim please review this PR and decide: approve, request changes, or block.',
+                ].join('\n'),
+              });
+            }


### PR DESCRIPTION
## Summary
- add PM/Dev automation operating model and guardrails for Claude PM + Codex Dev loop
- add label bootstrap workflow to keep automation labels consistent
- add state machine workflow for issue/PR transitions and completion comments
- add scheduled Claude review reminder workflow with escalation to `needs-human`
- add PR template and strengthen implementation issue template for DoD + automation limits

## Added Files
- `.github/workflows/automation-label-bootstrap.yml`
- `.github/workflows/automation-state-machine.yml`
- `.github/workflows/claude-review-scheduler.yml`
- `.github/automation/OPERATING_MODEL.md`
- `.github/pull_request_template.md`

## Updated Files
- `.github/ISSUE_TEMPLATE/task.md`

## Guardrails Implemented
- max automated issue attempts: 3 (`ready-codex` entry)
- max Claude reminder count: 3 (then `needs-human` + `blocked`)
- follow-up issue auto-creation only when PR has `auto-loop` label (opt-in)

## Notes
- This introduces workflow policy scaffolding; no product/runtime code paths are changed.
