### PR TITLE
fix(hwpx): preserve table-cell paragraph boundaries in markdown

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/roboco-io/hwp2md/internal/ir"
 )
 
 func TestSetVersion(t *testing.T) {
@@ -236,5 +239,17 @@ func TestDetectProviderFromModel(t *testing.T) {
 				t.Errorf("detectProviderFromModel(%q) = %q, want %q", tc.model, result, tc.expected)
 			}
 		})
+	}
+}
+
+func TestConvertToBasicMarkdown_TableCellParagraphsUseBreaks(t *testing.T) {
+	doc := ir.NewDocument()
+	table := ir.NewTable(1, 1)
+	table.Cells[0][0].Text = "문단1\n문단2\n문단3"
+	doc.AddTable(table)
+
+	md := convertToBasicMarkdown(doc)
+	if !strings.Contains(md, "문단1<br>문단2<br>문단3") {
+		t.Fatalf("expected markdown table cell to preserve paragraph boundaries with <br>, got: %s", md)
 	}
 }

--- a/internal/cli/convert.go
+++ b/internal/cli/convert.go
@@ -492,7 +492,7 @@ func writeMarkdownTable(sb *strings.Builder, t *ir.TableBlock) {
 			if ref.row >= 0 && ref.col >= 0 {
 				if ref.row == i && ref.col == j {
 					// This is the original cell
-					text = strings.ReplaceAll(t.Cells[i][j].Text, "\n", " ")
+					text = formatTableCellText(t.Cells[i][j].Text)
 				} else if ref.row < i && ref.col == j {
 					// Vertically merged cell (rowspan) - use 〃
 					text = "〃"
@@ -515,6 +515,12 @@ func writeMarkdownTable(sb *strings.Builder, t *ir.TableBlock) {
 		}
 	}
 	sb.WriteString("\n")
+}
+
+func formatTableCellText(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	return strings.ReplaceAll(text, "\n", "<br>")
 }
 
 // isInfoBoxTable detects "info-box" style tables that should be converted to text format.

--- a/internal/parser/hwpx/parser.go
+++ b/internal/parser/hwpx/parser.go
@@ -232,22 +232,12 @@ func (p *Parser) parseSectionXML(doc *ir.Document, decoder *xml.Decoder) error {
 				// Text element - read content
 				if currentParagraph != nil {
 					text, _ := readElementText(decoder)
-					cell := getCurrentCell()
-					if cell != nil {
-						cell.text.WriteString(text)
-					} else {
-						currentParagraph.Text += text
-					}
+					currentParagraph.Text += text
 				}
 
 			case "tab":
 				if currentParagraph != nil {
-					cell := getCurrentCell()
-					if cell != nil {
-						cell.text.WriteString("\t")
-					} else {
-						currentParagraph.Text += "\t"
-					}
+					currentParagraph.Text += "\t"
 				}
 
 			case "br":
@@ -259,12 +249,7 @@ func (p *Parser) parseSectionXML(doc *ir.Document, decoder *xml.Decoder) error {
 						}
 					}
 					if brType == "line" {
-						cell := getCurrentCell()
-						if cell != nil {
-							cell.text.WriteString("\n")
-						} else {
-							currentParagraph.Text += "\n"
-						}
+						currentParagraph.Text += "\n"
 					}
 				}
 

--- a/internal/parser/hwpx/parser_test.go
+++ b/internal/parser/hwpx/parser_test.go
@@ -276,6 +276,71 @@ func TestParser_ParseWithTable(t *testing.T) {
 	}
 }
 
+func TestParser_ParseWithTableCellMultiParagraph(t *testing.T) {
+	tmpDir := t.TempDir()
+	hwpxPath := filepath.Join(tmpDir, "table_multi_paragraph.hwpx")
+
+	f, err := os.Create(hwpxPath)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	w := zip.NewWriter(f)
+
+	manifestContent := `<?xml version="1.0" encoding="UTF-8"?>
+<opf:package xmlns:opf="http://www.idpf.org/2007/opf/">
+  <opf:manifest>
+    <opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/>
+  </opf:manifest>
+  <opf:spine><opf:itemref idref="section0"/></opf:spine>
+</opf:package>`
+	addZipFile(t, w, "content.hpf", []byte(manifestContent))
+
+	sectionContent := `<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:ht="http://www.hancom.co.kr/hwpml/2011/table">
+  <ht:tbl>
+    <ht:tr>
+      <ht:tc>
+        <hp:p><hp:run><hp:t>문단1</hp:t></hp:run></hp:p>
+        <hp:p><hp:run><hp:t>문단2</hp:t></hp:run></hp:p>
+        <hp:p><hp:run><hp:t>문단3</hp:t></hp:run></hp:p>
+      </ht:tc>
+    </ht:tr>
+  </ht:tbl>
+</hs:sec>`
+	addZipFile(t, w, "Contents/section0.xml", []byte(sectionContent))
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close file: %v", err)
+	}
+
+	p, err := New(hwpxPath, parser.Options{})
+	if err != nil {
+		t.Fatalf("failed to create parser: %v", err)
+	}
+	defer p.Close()
+
+	doc, err := p.Parse()
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	if len(doc.Content) != 1 || doc.Content[0].Table == nil {
+		t.Fatalf("expected one table block, got %+v", doc.Content)
+	}
+
+	got := doc.Content[0].Table.Cells[0][0].Text
+	want := "문단1\n문단2\n문단3"
+	if got != want {
+		t.Errorf("expected multi-paragraph cell text %q, got %q", want, got)
+	}
+}
+
 func TestReadElementText(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- preserve table-cell paragraph boundaries in HWPX parser by accumulating text into the paragraph buffer first
- keep per-paragraph separation (`\n`) when committing parsed table-cell text in `</hp:p>` handling
- render table-cell paragraph boundaries as `<br>` in markdown table output
- add regression tests for parser cell multi-paragraph handling and markdown rendering behavior

## Verification
- `go test ./internal/parser/hwpx ./internal/cli`
- `go test ./...`
- repro check:
  - `python3 tools/md2hwp/fill_hwpx.py testdata/fill_plans/재도전성공패키지_sample.json -o /tmp/phase4_para_after.hwpx`
  - `./bin/hwp2md /tmp/phase4_para_after.hwpx -o /tmp/phase4_para_after.md`
  - `rg -n "테스트 준비현황 문단" /tmp/phase4_para_after.md`
  - output now includes: `문단 1<br>문단 2<br>문단 3`

Closes #25
